### PR TITLE
Fix file listing having a href to the first file in a folder

### DIFF
--- a/EUS-wiki.js
+++ b/EUS-wiki.js
@@ -18,10 +18,26 @@ if (!fs.existsSync(__dirname + BASE_PATH + "/files")) {
     fs.mkdirSync(__dirname + BASE_PATH + "/files");
     console.log(`[EUS-wiki] Made EUS-wiki module files folder`);
     // Download page files
-    
     // Download page template files
     // needs to be done
 }
+if (!fs.existsSync(__dirname + BASE_PATH + "/files/css")) {
+    fs.mkdirSync(__dirname + BASE_PATH + "/files/css");
+    console.log(`[EUS-wiki] Made EUS-wiki module css folder`);
+}
+if (!fs.existsSync(__dirname + BASE_PATH + "/files/css/main.css")) {
+    download("https://raw.githubusercontent.com/tgpethan/EUS-wiki/master/EUS-wiki/files/css/main.css", __dirname + BASE_PATH + "/files/css");
+    console.log(`[EUS-wiki] Downloaded EUS-wiki main.css`);
+}
+if (!fs.existsSync(__dirname + BASE_PATH + "/files/js")) {
+    fs.mkdirSync(__dirname + BASE_PATH + "/files/js");
+    console.log(`[EUS-wiki] Made EUS-wiki module js folder`);
+}
+if (!fs.existsSync(__dirname + BASE_PATH + "/files/js/navHelper.js")) {
+    download("https://raw.githubusercontent.com/tgpethan/EUS-wiki/master/EUS-wiki/files/js/navHelper.js", __dirname + BASE_PATH + "/files/js");
+    console.log(`[EUS-wiki] Downloaded EUS-wiki navHelper.js`);
+}
+
 
 module.exports = {
     extras:async function() {

--- a/EUS-wiki.js
+++ b/EUS-wiki.js
@@ -156,7 +156,7 @@ function generatePageList(pageName) {
         if (s1[s1.length - 1] == "html") continue;
         if (s1.length >= 2) {
             // Has an extention, clearly a file.
-            pageList.push(new pageItem(pagesRoot[i].replace(".md", ""), s1[0], "/" + s1[0]));
+            pageList.push(new pageItem(pagesRoot[i].replace(".md", ""), s1[0], "/" + pagesRoot[i].replace(".md", "")));
         } else {
             // Probably a folder
             pageList.push(new folderItem(s1[0], getFolderContents(__dirname + BASE_PATH + "/EUS-wiki-pages/" + pagesRoot[i])));
@@ -207,8 +207,8 @@ function getFolderContents(s) {
         const s1 = pages[i].split(".");
         if (s1.length >= 2) {
             // Has an extention, clearly a file.
-            const fle = `${s}/${pages[0]}`.split("/EUS-wiki-pages");
-            list.push(new pageItem(s1[0], `${s}/${pages[0]}`, fle[fle.length - 1].replace(".md", "")));
+            const fle = `${s}/${pages[i]}`.split("/EUS-wiki-pages");
+            list.push(new pageItem(s1[0], `${s}/${pages[i]}`, fle[fle.length - 1].replace(".md", "")));
         } else {
             // Probably a folder
             list.push(new folderItem(s1[0], getFolderContents(`${s}/${pages[i]}`)));


### PR DESCRIPTION
Found while working on EUS-wiki-pages.
If the page listing has more than one file all other files in that category will only have a href to the first item.